### PR TITLE
"Go To Qualified Class" feature

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -5,6 +5,10 @@
         "command": "go_to_class"
     },
     {
+        "caption": "Go To Qualified Class",
+        "command": "go_to_fully_qualified_class"
+    },
+    {
         "caption": "Go To Parent Class",
         "command": "go_to_parent_class"
     },

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -4,6 +4,10 @@
         "command": "go_to_class"
     },
     {
+        "keys": ["ctrl+shift+alt+o"],
+        "command": "go_to_fully_qualified_class"
+    },
+    {
         "keys": ["ctrl+shift+o"],
         "command": "go_to_parent_class"
     },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -4,6 +4,10 @@
         "command": "go_to_class"
     },
     {
+        "keys": ["ctrl+shift+super+o"],
+        "command": "go_to_fully_qualified_class"
+    },
+    {
         "keys": ["super+shift+o"],
         "command": "go_to_parent_class"
     },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -4,6 +4,10 @@
         "command": "go_to_class"
     },
     {
+        "keys": ["ctrl+shift+alt+o"],
+        "command": "go_to_fully_qualified_class"
+    },
+    {
         "keys": ["ctrl+shift+o"],
         "command": "go_to_parent_class"
     },

--- a/GoToClass.py
+++ b/GoToClass.py
@@ -1,6 +1,5 @@
 import sublime
 import sublime_plugin
-import re
 
 
 class GoToClassCommand(sublime_plugin.TextCommand):
@@ -18,17 +17,16 @@ class GoToClassCommand(sublime_plugin.TextCommand):
 
 class GoToParentClassCommand(sublime_plugin.TextCommand):
     def run(self, edit):
-        content = self.view.substr(sublime.Region(0, self.view.size()))
-        # TODO match class declaration lines: class\s+(.*)\s+{. Then remove comments and find the parent class names
-        pattern = re.compile('^\s*(final\s+|abstract\s+)*class\s+\S+\s+extends\s+(\S+)', re.MULTILINE|re.IGNORECASE)
-        matches = pattern.findall(content)
+        regions = self.view.find_by_selector('entity.other.inherited-class.php')
 
-        if len(matches) == 0:
+        if len(regions) == 0:
             return;
 
-        # transform matches into list of unique parent class names
         parent_class = []
-        [parent_class.append(match[1]) for match in matches if match[1] not in parent_class]
+        for region in regions:
+            string = self.view.substr(region)
+            if string not in parent_class:
+                parent_class.append(string)
 
         if len(parent_class) > 1:
             def on_parent_class_select(index):

--- a/GoToClass.py
+++ b/GoToClass.py
@@ -10,7 +10,7 @@ import sublime_plugin
 def getFullyQualifiedClassName(view, string, selection = False):
     # If string starts with a backslash - do nothing
     if string[0] == '\\':
-        return string
+        return string.strip('\\')
 
     found = False
     alias = string.split('\\')[0];
@@ -18,7 +18,7 @@ def getFullyQualifiedClassName(view, string, selection = False):
     # check if we inside 'namespace' or 'use' lines
     if selection != False:
         if view.match_selector(selection.begin(), 'meta.namespace.php'):
-            return '\\' + string
+            return string
 
         if view.match_selector(selection.begin(), 'meta.use.php'):
             found = True # hack to skip 'meta.namespace.php' logic below
@@ -52,7 +52,7 @@ def getFullyQualifiedClassName(view, string, selection = False):
             namespace = view.substr(region);
             string = namespace.split()[1] + string
 
-    return '\\' + string.strip('\\')
+    return string.strip('\\')
 
 
 class GoToClassCommand(sublime_plugin.TextCommand):

--- a/GoToClass.py
+++ b/GoToClass.py
@@ -2,6 +2,59 @@ import sublime
 import sublime_plugin
 
 
+"""Generate fully qualified class name
+
+1. If string does not start with a backslash, search 'Result' in 'use'
+2. If not found, join the string with a 'namespace'
+"""
+def getFullyQualifiedClassName(view, string, selection = False):
+    # If string starts with a backslash - do nothing
+    if string[0] == '\\':
+        return string
+
+    found = False
+    alias = string.split('\\')[0];
+
+    # check if we inside 'namespace' or 'use' lines
+    if selection != False:
+        if view.match_selector(selection.begin(), 'meta.namespace.php'):
+            return '\\' + string
+
+        if view.match_selector(selection.begin(), 'meta.use.php'):
+            found = True # hack to skip 'meta.namespace.php' logic below
+
+            # if we select string in 'as' statement, then the whole string
+            # is not a classname but an alias and we should remove it,
+            # as it does not contain any real information.
+            # Example: 'use Magento\Framework\App\Action\Action as Hello;'
+            # If string is 'Hello' - get rid of it. All info that we need
+            # is in alias variable now.
+            if string.find('\\') == -1:
+                string = ''
+
+    if len(string) > 0:
+        string = '\\' + string
+
+    # Search alias in 'uses'
+    for region in view.find_by_selector('meta.use.php'):
+        use = view.substr(region);
+        if not use.endswith(alias):
+            continue
+        found = True
+        class_name = use.split()[1]
+        string = string[(len(alias) + 1):]
+        string = class_name + string
+        break
+
+    # Join '\string' with a 'namespace'
+    if found == False:
+        for region in view.find_by_selector('meta.namespace.php'):
+            namespace = view.substr(region);
+            string = namespace.split()[1] + string
+
+    return '\\' + string.strip('\\')
+
+
 class GoToClassCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         settings = self.view.settings()
@@ -15,6 +68,29 @@ class GoToClassCommand(sublime_plugin.TextCommand):
             self.view.window().run_command("show_overlay", {"overlay": "goto", "text": word_sel})
 
 
+class GoToFullyQualifiedClassCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        settings = self.view.settings()
+        separator = settings.get("go_to_class_separator")
+        expand_separators = " []|!{}()<>-+$:;.,'*\n\""
+
+        for sel in self.view.sel():
+            sel = self.view.word(sel)
+
+            # Expand selection to include all phrase with backslashes
+            sel = self.view.expand_by_class(
+                sel,
+                sublime.CLASS_WORD_START | sublime.CLASS_WORD_END,
+                expand_separators
+            );
+
+            string = self.view.substr(sel).strip(expand_separators)
+            string = getFullyQualifiedClassName(self.view, string, sel)
+
+            string = string.replace(separator, ' ')
+            self.view.window().run_command("show_overlay", {"overlay": "goto", "text": string})
+
+
 class GoToParentClassCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         regions = self.view.find_by_selector('entity.other.inherited-class.php')
@@ -25,6 +101,7 @@ class GoToParentClassCommand(sublime_plugin.TextCommand):
         parent_class = []
         for region in regions:
             string = self.view.substr(region)
+            string = getFullyQualifiedClassName(self.view, string)
             if string not in parent_class:
                 parent_class.append(string)
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Sublime Text Plugin to open the class file of the highlighted name.  Works in ST
 -----
 
 * Highlight My_Special_Class_File, right click, choose "Go To Class", and it will select My/Special/Class/File using the fuzzy search
+* Highlight `IdentityInterface`, right click, choose "Go To Qualified Class", and
+	it will select `Magento\Framework\DataObject\IdentityInterface` using the
+	fuzzy search (Name will be generated according to 'use' and 'namespace'
+	statements)
 * Press "Go To Parent Class" keybinding, and it will select parent class My/Special/Class/File using the fuzzy search
 * Highlight My_Function, right click, choose "Go To Function", and it will select My_Function using the fuzzy search prefixed with '@'
 * Highlight My_Data, right click, choose "Go To Data", and it will select My_Data using the fuzzy search prefixed with '#'
@@ -19,6 +23,12 @@ Go To Class
 	Mac OS X: CTRL+CMD+O
 	Windows:  CTRL+ALT+O
 	Linux:    CTRL+ALT+O
+
+Go To Qualified Class
+
+	Mac OS X: CTRL+SHIFT+CMD+O
+	Windows:  CTRL+SHIFT+ALT+O
+	Linux:    CTRL+SHIFT+ALT+O
 
 Go To Parent Class
 


### PR DESCRIPTION
1. Removed not needed regexp usage when searching for parent class. It's much faster and accurate.
2. Added "GoToFullyQualifiedClassCommand":

This feature uses 'namespace' and 'uses' statements to get a
 correct class name.

Not a real-life example. Just for presentation:

```php
<?php

namespace Third\Party\Controller\Click;

use Magento\Framework\App\Action\Action;
use Magento\Framework\App\Action\Action as Hello;

class Index extends Action
{
    public function __construct(
        Action $action1,
        Action\Test $test1,
        Hello $action2,
        Hello\Test $test2
    )
    {
    }
}
```

All classes will be generated correctly for the case above.
GoToParentClassCommand will also generate correct Action class name.
